### PR TITLE
extracts data-list componet

### DIFF
--- a/app/javascript/src/Dashboard/components/APIDataListItem.jsx
+++ b/app/javascript/src/Dashboard/components/APIDataListItem.jsx
@@ -1,0 +1,89 @@
+import React, { useState, useRef } from 'react'
+
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  KebabToggle,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  DataListItemCells,
+  DataListAction
+} from '@patternfly/react-core'
+
+type Props = {
+  api: {
+    id: number,
+    link: string,
+    links: Array<{
+      name: string,
+      path: string
+    }>,
+    name: string,
+    type: string,
+    updated_at: string
+  }
+}
+
+const APIDataListItem = ({ api }: Props) => {
+  const { id, name, updated_at: updatedAt, link, links } = api
+  const [isOpen, setIsOpen] = useState(false)
+  const ref = useRef(null)
+  // TODO: useClickOutside(ref, () => setIsOpen(false))
+
+  return (
+    <DataListItem key={id} aria-labelledby="single-action-item1">
+      <DataListItemRow>
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key="primary content">
+              <a href={link} id="single-action-item1">
+                {name}
+              </a>
+            </DataListCell>,
+            <DataListCell key="secondary content" className="dashboard-list-secondary">
+              {updatedAt}
+            </DataListCell>
+          ]}
+        />
+        <DataListAction
+          aria-labelledby="multi-actions-item1 multi-actions-action1"
+          id="actions-menu"
+          aria-label="Actions"
+          isPlainButtonAction
+        >
+          <Dropdown
+            isPlain
+            id="actions-menu"
+            ref={ref}
+            position={DropdownPosition.right}
+            isOpen={isOpen}
+            className="dashboard-list-item-action"
+            onClick={() => setIsOpen(!isOpen)}
+            toggle={<KebabToggle id={id.toString()} />}
+            dropdownItems={[
+              <DropdownItem key={`link-${links[0].path}`} href={links[0].path}>
+                Edit
+              </DropdownItem>,
+              <DropdownItem key={`link-${links[1].path}`} href={links[1].path}>
+                Overview
+              </DropdownItem>,
+              <DropdownItem key={`link-${links[2].path}`} href={links[2].path}>
+                Analytics
+              </DropdownItem>,
+              <DropdownItem key={`link-${links[3].path}`} href={links[3].path}>
+                Methods and Metrics
+              </DropdownItem>,
+              <DropdownItem key={`link-${links[4].path}`} href={links[4].path}>
+                Mapping Rules
+              </DropdownItem>
+            ]}
+          />
+        </DataListAction>
+      </DataListItemRow>
+    </DataListItem>
+  )
+}
+
+export { APIDataListItem }

--- a/app/javascript/src/Dashboard/components/BackendsWidget.jsx
+++ b/app/javascript/src/Dashboard/components/BackendsWidget.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, {useState} from 'react'
+import React from 'react'
 import {
   Button,
   Card,
@@ -9,18 +9,10 @@ import {
   CardHeader,
   CardFooter,
   Title,
-  Dropdown,
-  DropdownItem,
-  DropdownPosition,
-  KebabToggle,
-  DataList,
-  DataListItem,
-  DataListCell,
-  DataListItemRow,
-  DataListItemCells,
-  DataListAction
+  DataList
 } from '@patternfly/react-core'
 import CubesIcon from '@patternfly/react-icons/dist/js/icons/cubes-icon'
+import { APIDataListItem } from 'Dashboard/components/APIDataListItem'
 import 'Dashboard/styles/dashboard.scss'
 import 'patternflyStyles/dashboard'
 
@@ -46,82 +38,6 @@ const BackendsWidget = (props: Props) => {
   console.log('what are the props' + JSON.stringify(props))
   console.log('what are the props 2' + JSON.stringify(props.backends[0].name))
 
-  const [ isOpenArray, setIsOpenArray ] = useState([])
-
-  function handleChange (e) {
-    const item = e.target.id
-    var indexOfItem = isOpenArray.indexOf(item)
-
-    if (indexOfItem !== -1) {
-      var array = [...isOpenArray]
-      if (indexOfItem === 0) {
-        array.shift()
-        setIsOpenArray(array)
-      } else {
-        var newArray = array.splice(indexOfItem, 1)
-        setIsOpenArray(newArray)
-      }
-    } else {
-      setIsOpenArray([item, ...isOpenArray])
-    }
-  }
-
-  const APIDataListItem = props.backends.map((api, index) => {
-    let dateUpdatedAt = new Date(api.updated_at)
-
-    return (
-      <DataListItem key={api.id} aria-labelledby="single-action-item1">
-        <DataListItemRow>
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="primary content">
-                <a href={api.link} id="single-action-item1">
-                  {api.name}
-                </a>
-              </DataListCell>,
-              <DataListCell key="secondary content" className="dashboard-list-secondary">
-                {dateUpdatedAt.toUTCString()}
-              </DataListCell>
-            ]}
-          />
-          <DataListAction
-            aria-labelledby="multi-actions-item1 multi-actions-action1"
-            id="actions-menu"
-            aria-label="Actions"
-            isPlainButtonAction
-          >
-            <Dropdown
-              isPlain
-              id="actions-menu"
-              position={DropdownPosition.right}
-              isOpen={isOpenArray.indexOf(`toggle-${index}`) !== -1}
-              className="dashboard-list-item-action"
-              onClick={handleChange}
-              toggle={<KebabToggle id={`toggle-${index}`} />}
-              dropdownItems={[
-                <DropdownItem key={`link-${index}`} href={api.links[0].path}>
-                  Edit
-                </DropdownItem>,
-                <DropdownItem key={`link-${index}`} href={api.links[1].path}>
-                  Overview
-                </DropdownItem>,
-                <DropdownItem key={`link-${index}`} href={api.links[2].path}>
-                  Analytics
-                </DropdownItem>,
-                <DropdownItem key={`link-${index}`} href={api.links[3].path}>
-                  Methods and Metrics
-                </DropdownItem>,
-                <DropdownItem key={`link-${index}`} href={api.links[4].path}>
-                  Mapping Rules
-                </DropdownItem>
-              ]}
-            />
-          </DataListAction>
-        </DataListItemRow>
-      </DataListItem>
-    )
-  })
-
   return (
     <Card className="pf-c-card">
       <CardHeader>
@@ -142,7 +58,7 @@ const BackendsWidget = (props: Props) => {
       </CardHeader>
       <CardBody>
         <DataList>
-          {APIDataListItem}
+          {props.backends.map(api => <APIDataListItem api={api} key={api.id}/>)}
         </DataList>
       </CardBody>
       <CardFooter>


### PR DESCRIPTION
Here's the example for our conversation https://github.com/3scale/porta/pull/2198/files#r501578707

### Summary
We get rid of the state `isOpenArray` in the parent component and instead delegate it to each of the children (DataList). Since hooks has to be declared at the top of the component, we need to extract APIDataListItem to its own component (the fact that it's in a separated file is just my own preference).

Additional note:
I recently added a custom hook `useClickOutside` to handle clicks outside components. By adding [this line](https://github.com/christiemolloy/porta/compare/addDashboardWidgets...josemigallas:data-list-item-refactor?expand=1#diff-7a7ffd7b65b598711ceee8b0845232caR33) the dropdown will close when the user clicks something else (like other dropdown).