### PR TITLE
adds current_api data to vertical nav container

### DIFF
--- a/app/views/shared/provider/navigation/_vertical_nav.html.slim
+++ b/app/views/shared/provider/navigation/_vertical_nav.html.slim
@@ -1,10 +1,14 @@
 = javascript_pack_tag 'vertical_nav'
 
+- api = current_api.to_json if current_api.present?
 - sections = vertical_nav_sections || []
 - active_section = active_submenu
 - active_item = active_sidebar
 
-#vertical-nav-wrapper class='pf-c-page__sidebar pf-m-dark' data-sections=sections.to_json data-active_section=active_section data-active_item=active_item
+#vertical-nav-wrapper class='pf-c-page__sidebar pf-m-dark' data={ current_api: current_api,
+                                                                  sections: sections.to_json,
+                                                                  active_section: active_section,
+                                                                  active_item: active_item }.compact
 
   div.pf-c-page__sidebar-body
     nav#mainmenu class='pf-c-nav'


### PR DESCRIPTION
The data will be available in the existing dataset:
```diff
import { VerticalNavWrapper as VerticalNav } from 'Navigation/components/VerticalNav'
import { safeFromJsonString } from 'utilities/json-utils'

document.addEventListener('DOMContentLoaded', () => {
  const dataset = document.getElementById('vertical-nav-wrapper').dataset
  const sections = safeFromJsonString(dataset.sections)
  const activeSection = dataset.active_section
  const activeItem = dataset.active_item
+  const currentApi = dataset.current_api

  VerticalNav({ sections, activeSection, activeItem, currentApi: safeFromJsonString(currentApi) }, 'vertical-nav-wrapper')
})
```
